### PR TITLE
os-278 Reenable sslv3 in the java-7-jre

### DIFF
--- a/manifests/profile/ifmapserver.pp
+++ b/manifests/profile/ifmapserver.pp
@@ -5,6 +5,24 @@ class contrail::profile::ifmapserver() {
     ensure => installed,
   }
 
+  service {'ifmap-server':
+    ensure => running,
+  }
+
+  augeas { 'java-7-openjdk_java.security':
+    lens => 'Properties.lns',
+    incl => '/etc/java-7-openjdk/security/java.security',
+    context => '/files/etc/java-7-openjdk/security/java.security',
+    changes => [
+      # FIXME: Reenable any disabled TLS algorithms
+      #
+      # This is needed because many contrail components are using hardcoded SSLv3
+      # which is disabled by default in java upstream
+      'rm jdk.tls.disabledAlgorithms',
+    ],
+    notify => Service['ifmap-server'],
+  }
+
   file {'/etc/ifmap-server/basicauthusers.properties':
     ensure  => file,
     content => template("$module_name/ifmap-server/basicauthusers.properties.erb"),


### PR DESCRIPTION
This has been done in the place where the failure has been observed for
now.

If this is needed on different nodes/for different java versions as
well, refactor accordingly